### PR TITLE
Add SpEd footer to auth pages

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -2,23 +2,30 @@ import LoginForm from './login-form';
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div>
-          {/* Logo */}
-          <div className="flex justify-center mb-6">
-            <span className="text-5xl font-logo text-gray-900">Speddy</span>
-          </div>
+    <div className="min-h-screen flex flex-col bg-gray-50">
+      <div className="flex-1 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-md w-full space-y-8">
+          <div>
+            {/* Logo */}
+            <div className="flex justify-center mb-6">
+              <span className="text-5xl font-logo text-gray-900">Speddy</span>
+            </div>
 
-          <h2 className="mt-6 text-center text-2xl font-semibold text-gray-900">
-            The friendly SpEd platform :)
-          </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
-            Sign in (or up) to make your SpEd life easier!
-          </p>
+            <h2 className="mt-6 text-center text-2xl font-semibold text-gray-900">
+              The friendly SpEd platform :)
+            </h2>
+            <p className="mt-2 text-center text-sm text-gray-600">
+              Sign in (or up) to make your SpEd life easier!
+            </p>
+          </div>
+          <LoginForm />
         </div>
-        <LoginForm />
       </div>
+      
+      {/* Footer */}
+      <footer className="py-4 text-center text-sm text-gray-600">
+        Made by SpEd people, for SpEd people.
+      </footer>
     </div>
   );
 }

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -22,6 +22,11 @@ export default function SignupPage() {
           <SignupForm />
         </div>
       </div>
+      
+      {/* Footer */}
+      <footer className="py-4 text-center text-sm text-gray-600">
+        Made by SpEd people, for SpEd people.
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## Changes
This PR adds a footer to both the login and signup pages with the text: "Made by SpEd people, for SpEd people."

### What changed:
1. **Login page** (`app/(auth)/login/page.tsx`):
   - Changed the wrapper from a centered div to a flex column layout
   - Added footer at the bottom of the page

2. **Signup page** (`app/(auth)/signup/page.tsx`):
   - Added matching footer (page already had flex column layout)

### Visual impact:
- Footer appears at the bottom of both auth pages
- Uses subtle gray text (`text-gray-600`) to match existing styling
- Small text size (`text-sm`) to keep it unobtrusive

### Testing:
Please verify the footer appears correctly on both:
- `/login` page
- `/signup` page